### PR TITLE
Recreating setup.py for installing local packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='src',
+    packages=find_packages(),
+    version='0.1.0',
+    description='Analysis of inverting the dynamic structure factor to obtain a collision frequency, based on the Me.',
+    author='Thomas Hentschel',
+    license='MIT',
+)


### PR DESCRIPTION
Accidentally deleted the premade setup.py file early on. Adding it back because its necessary to import the src folder.