### PR TITLE
Fix to plot correct collision & ELF data

### DIFF
--- a/notebooks/exploratory/5.0-twh-inferrence-AAcollisions.md
+++ b/notebooks/exploratory/5.0-twh-inferrence-AAcollisions.md
@@ -400,7 +400,9 @@ runinfo = {
 ndim = 5 # number of parameters
 numchains = 32
 numsamples = 25_000
+```
 
+```{code-cell} ipython3
 # # avoid overwriting datasets
 # dataset = unique_hdf5_group(samplesfile, dataset)
 backend = emcee.backends.HDFBackend(samplesfile, name=dataset)
@@ -428,7 +430,7 @@ with h5py.File(samplesfile, "a") as f:
 # # view attributes of dataset
 # with h5py.File(samplesfile, "a") as f:
 #     print(list(f.keys()))
-#     dset = f["mcmc_samples"]
+#     dset = f["mcmc_samples_AAdata"]
 #     for attr in dset.attrs:
 #         print(f"{attr} : {dset.attrs[attr]}")
 ```
@@ -464,7 +466,7 @@ paramnames = (
     "logistic_gradient"
 )
 fig, axes = plt.subplots(ndim, figsize=(10,2.5*5), sharex=True)
-samples = sampler.get_chain()
+samples = backend.get_chain()
 for i in range(ndim):
     ax = axes[i]
     ax.plot(samples[:,:,i], 'k', alpha=0.3)
@@ -533,8 +535,4 @@ plt.xlabel(r"$\hbar\omega$ [eV]")
 plt.ylim(1e-6)
 plt.legend()
 # plt.savefig("../../reports/figures/mcmc_AAdata_ELFsamples")
-```
-
-```{code-cell} ipython3
-
 ```

--- a/notebooks/exploratory/5.1-twh-inferrence-model-data.md
+++ b/notebooks/exploratory/5.1-twh-inferrence-model-data.md
@@ -102,7 +102,7 @@ popt_AAcoll, pcov = optimize.curve_fit(
     (1,1,1,1,1),
     bounds=(0, np.inf)
 )
-print(popt)
+print(popt_AAcoll)
 
 # plot to compare
 plt.semilogx(freq_data, (AAcoll := AA_collrate_fn(freq_data / AtomicUnits.energy)).real, c="C0", label="AA")
@@ -193,7 +193,7 @@ residual = partial(residual_fn,
                    type="rel"
                   )
 # initial parameter guesses
-initparams = (1, 1, 1, 1, 1)
+initparams = (0.1, 0.1, 2, 1, 10)
 
 # optimization results
 optresult = optimize.least_squares(residual, initparams, bounds=(0, np.inf), max_nfev=150)
@@ -392,11 +392,13 @@ logposterior(optresult.x)
 We will use the results from the optimization to initialize the Markov chains.
 
 ```{code-cell} ipython3
-import h5py
-from datetime import datetime
-
 samplesfile = "../../data/mcmc/mcmc_modeldata"
 dataset = "mcmc_samples_modeldata"
+```
+
+```{code-cell} ipython3
+import h5py
+from datetime import datetime
 runinfo = {
     "date" : datetime.today().strftime('%a %d %b %Y, %I:%M%p'),
     "input data info" : f"""Data generated using collision rate model
@@ -413,7 +415,9 @@ runinfo = {
 ndim = 5 # number of parameters
 numchains = 32
 numsamples = 25_000
+```
 
+```{code-cell} ipython3
 # # avoid overwriting datasets
 # dataset = unique_hdf5_group(samplesfile, dataset)
 backend = emcee.backends.HDFBackend(samplesfile, name=dataset)
@@ -453,7 +457,7 @@ backend = emcee.backends.HDFBackend(samplesfile, name=dataset)
 ```
 
 ```{code-cell} ipython3
-tau = backend.get_autocorr_time(tol=0)
+tau = backend.get_autocorr_time()
 burnin = int(2 * np.max(tau))
 thin = int(0.5 * np.min(tau))
 flat_samples = backend.get_chain(discard=burnin, flat=True, thin=thin)
@@ -477,7 +481,7 @@ paramnames = (
     "logistic_gradient"
 )
 fig, axes = plt.subplots(ndim, figsize=(10,2.5*5), sharex=True)
-samples = sampler.get_chain()
+samples = backend.get_chain()
 for i in range(ndim):
     ax = axes[i]
     ax.plot(samples[:,:,i], 'k', alpha=0.3)
@@ -507,11 +511,11 @@ for ind in inds:
                 alpha=0.1
               )
 
-# plot AA collision frequency
+# plot true collision frequency
 plt.plot(freq_data,
-         true_collrate_fn(freq_data / AtomicUnits.energy).real,
+         collisionrate(freq_data / AtomicUnits.energy, popt_AAcoll).real,
          c="k",
-         label="Avg. Atom",
+         label="true",
          lw=2,
          ls='--'
         )
@@ -538,7 +542,7 @@ for ind in inds:
                  "C1", 
                  alpha=0.1)
 # plot data
-plt.loglog(freq_data, elf_data, c="k", label="Avg. Atom", lw=2, ls='--')
+plt.loglog(freq_data, elf_data, c="k", label="true ELF", lw=2, ls='--')
 
 plt.ylabel("ELF [au]")
 plt.xlabel(r"$\hbar\omega$ [eV]")


### PR DESCRIPTION
Using the correct model collision rate instead of the average atom collision rate in the final plots in notebook 5.1. Also separating the mcmc sample run, which can take over 1 1/2 hrs, into its own cell.